### PR TITLE
toilets.json has a syntax error

### DIFF
--- a/extras/osmtags/facilities/toilets.json
+++ b/extras/osmtags/facilities/toilets.json
@@ -15,7 +15,7 @@
                           ]
                       }, "type":"stringcombo"
                     },
-                    {"key":"fee", "value":"",  "type":"boolean"}
+                    {"key":"fee", "value":"",  "type":"boolean"},
                     {"key":"note", "value":"", "type":"string"},
                     {"key":"LONGITUDE", "value":"", "type":"hidden"},
                     {"key":"LATITUDE", "value":"", "type":"hidden"}


### PR DESCRIPTION
Array's values must be separated by comma. But toilets.json forgot the comma.
