### PR TITLE
added logic to update name field of dataproperties when needed.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 ext {
-    geopaparazziVersion = "3.9.0"
+    geopaparazziVersion = "3.9.0.dataproperties"
 }
 
 buildscript {

--- a/geopaparazzispatialitelibrary/src/eu/geopaparazzi/spatialite/database/spatial/core/SpatialVectorTable.java
+++ b/geopaparazzispatialitelibrary/src/eu/geopaparazzi/spatialite/database/spatial/core/SpatialVectorTable.java
@@ -73,6 +73,7 @@ public class SpatialVectorTable {
     // list of possible primary keys - for more that one: seperated with ';'
     private String s_primary_key_fields="";
     private String s_unique_name=""; // file-name+table-name+field-name
+    private String s_unique_name_base=""; // file-name+table-name+field-name
 
     public SpatialVectorTable( String  s_map_file,String s_table_name, String s_geometry_column, int geomType, String srid, double[] center , double[] bounds,
      String s_layer_type,int i_row_count,int i_coord_dimension,int i_spatial_index_enabled,String s_last_verified ) {
@@ -118,6 +119,7 @@ public class SpatialVectorTable {
                     relativePath = relativePath.substring(1);
                 }
                 sb.append(relativePath);
+                s_unique_name_base=this.s_name_file+File.separator+s_table_name+File.separator+s_geometry_column;
                 sb.append(File.separator);
                 sb.append(s_table_name);
                 sb.append(File.separator);
@@ -309,8 +311,28 @@ public class SpatialVectorTable {
     public String getGeomName() {
         return s_geometry_column;
     }
+    /**
+      * Unique-Name of Geometry Field inside 'sdcard/maps' directory
+      * - needed to identify one specfic field inside the whole Maps-Directory
+      * -- Sample: '/storage/emulated/0/maps/aurina/aurina.sqlite/topcloud/Geometry'
+      * --- Maps-Directory:  ''/storage/emulated/0/maps/'
+      * --- Directory inside the Maps-Directory: 'aurina/'
+      * --- UniqueNameBase : 'aurina.sqlite/topcloud/Geometry'
+      * -- Result : 'aurina/aurina.sqlite/topcloud/Geometry'
+      */
     public String getUniqueName() {
         return this.s_unique_name;
+    }
+    /**
+      * Unique-Name-Base of Database inside 'sdcard/maps' directory
+      * - needed to Directory portion if the Database has been moved
+      * -- Sample: '/storage/emulated/0/maps/aurina/aurina.sqlite/topcloud/Geometry'
+      * --- Maps-Directory:  ''/storage/emulated/0/maps/'
+      * --- Directory inside the Maps-Directory: 'aurina/'
+      * -- Result : 'aurina.sqlite/topcloud/Geometry'
+      */
+    public String getUniqueNameBase() {
+        return this.s_unique_name_base;
     }
     public int getGeomType() {
         return geomType;


### PR DESCRIPTION
This could resolve the automatic updating of the name field when needed.
- this has been tested and works

Logic was build in to create a copy of dataproperties ( `dataproperties_save`) 
- when the column_count is different than the static column_count
  - a new dataproperties will be created with default values
  - old values will be updated to the new values
    - here I forgot the 'DROP' statement to the dataproperties_save after the UPDATE
  - this portion has **_NOT**_ been tested

**_TODO**_: 
- check if the any of the old fields have been renamed or deleted
  - otherwise the UPDATE will fail
- 'DROP' statement to the `dataproperties_save` table after the UPDATE

I assume when support for Geometry Labels are build in
- `dataproperties' will receive 2 new Fields
  - this could then be tested
