### PR TITLE
fix #137

### DIFF
--- a/geopaparazzimapsforge/src/eu/geopaparazzi/mapsforge/mapsdirmanager/maps/tiles/CustomTileDownloader.java
+++ b/geopaparazzimapsforge/src/eu/geopaparazzi/mapsforge/mapsdirmanager/maps/tiles/CustomTileDownloader.java
@@ -344,7 +344,7 @@ public class CustomTileDownloader extends TileDownloader {
         this.centerY = center[1];
         if (bounds == null) {
             double ddeg = 3.0;
-            bounds = new double[]{centerX - ddeg, centerY - ddeg, centerX + ddeg, centerY + ddeg};
+            bounds = new double[]{-180.0, -85.05113, 180, 85.05113};
         }
         this.boundsWest = bounds[0];
         this.boundsSouth = bounds[1];


### PR DESCRIPTION
When map's bounds don't set on mapurl, they assume too small bounds around map center. If current position is out of that bounds, correct current position value to map center. But I can't think of the reason of too small bounds.

Resolve #137 by changing default boudns to worldwide.
