### PR TITLE
create capability for specifying custom maps folder

### DIFF
--- a/geopaparazzi.app/res/values/strings.xml
+++ b/geopaparazzi.app/res/values/strings.xml
@@ -233,4 +233,10 @@
     <string name="map">Map</string>
     <string name="name">name</string>
     <string name="bounds">bounds</string>
+    <string name="storage_settings">Storage Preferences</string>
+    <string name="use_custom_maps_folder_summary">Change the folder from which basemaps and spatialite data are accessed.</string>
+    <string name="custom_maps_folder">Custom maps folder</string>
+    <string name="set_maps_folder_manually">Set the maps folder manually (text here has precedence over combobox)</string>
+    <string name="choose_from_suggested_folders">or choose from a filtered list of folders containing the word maps</string>
+    <string name="restart_after_setting_maps_folder">You must restart Geopaparazzi if you change the maps folder!</string>
 </resources>

--- a/geopaparazzi.app/res/xml/my_preferences.xml
+++ b/geopaparazzi.app/res/xml/my_preferences.xml
@@ -112,14 +112,24 @@
             android:summary="@string/spatialite_recover_mode_tooltip" >
         </CheckBoxPreference>
     </PreferenceScreen>
-
-    <eu.hydrologis.geopaparazzi.preferences.CustomSdcardPathPreference
-        android:defaultValue=""
-        android:key="PREFS_KEY_CUSTOM_EXTERNALSTORAGE"
-        android:order="100"
-        android:summary="@string/use_custom_sdcard_summary"
-        android:title="@string/custom_sdcard_path" />
-
+    
+    <PreferenceScreen
+        android:order="99"
+        android:title="@string/storage_settings" >
+	    <eu.hydrologis.geopaparazzi.preferences.CustomSdcardPathPreference
+	        android:defaultValue=""
+	        android:key="PREFS_KEY_CUSTOM_EXTERNALSTORAGE"
+	        android:order="100"
+	        android:summary="@string/use_custom_sdcard_summary"
+	        android:title="@string/custom_sdcard_path" />
+	    <eu.hydrologis.geopaparazzi.preferences.CustomMapsFolderPreference
+	        android:defaultValue="maps"
+	        android:key="PREFS_KEY_CUSTOM_MAPSFOLDER"
+	        android:order="110"
+	        android:summary="@string/use_custom_maps_folder_summary"
+	        android:title="@string/custom_maps_folder" />
+    </PreferenceScreen>
+    
     <PreferenceScreen
         android:order="200"
         android:title="@string/osm_preferences" >

--- a/geopaparazzi.app/src/eu/hydrologis/geopaparazzi/preferences/CustomMapsFolderPreference.java
+++ b/geopaparazzi.app/src/eu/hydrologis/geopaparazzi/preferences/CustomMapsFolderPreference.java
@@ -1,0 +1,182 @@
+/*
+ * Geopaparazzi - Digital field mapping on Android based devices
+ * Copyright (C) 2010  HydroloGIS (www.hydrologis.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package eu.hydrologis.geopaparazzi.preferences;
+
+import java.util.List;
+
+import android.content.Context;
+import android.content.res.TypedArray;
+import android.preference.DialogPreference;
+import android.util.AttributeSet;
+import android.view.View;
+import android.view.ViewGroup.LayoutParams;
+import android.widget.ArrayAdapter;
+import android.widget.EditText;
+import android.widget.LinearLayout;
+import android.widget.Spinner;
+import android.widget.TextView;
+import eu.geopaparazzi.library.database.GPLog;
+import eu.geopaparazzi.library.util.FileUtilities;
+import eu.geopaparazzi.library.util.ResourcesManager;
+import eu.hydrologis.geopaparazzi.R;
+
+/**
+ * A custom maps folder chooser.
+ * 
+ * @author Andrea Antonello (www.hydrologis.com); adapted for folders by Tim Howard (nynhp.org)
+ *
+ */
+public class CustomMapsFolderPreference extends DialogPreference {
+    private Context context;
+    private EditText editView;
+    private String customFolder = ""; //$NON-NLS-1$
+    private Spinner guessedFolderSpinner;
+    private List<String> guessedFoldersList;
+    /**
+     * @param ctxt  the context to use.
+     * @param attrs attributes.
+     */
+    public CustomMapsFolderPreference( Context ctxt, AttributeSet attrs ) {
+        super(ctxt, attrs);
+        this.context = ctxt;
+        setPositiveButtonText(ctxt.getString(android.R.string.ok));
+        setNegativeButtonText(ctxt.getString(android.R.string.cancel));
+    }
+
+    @Override
+    protected View onCreateDialogView() {
+        LinearLayout mainLayout = new LinearLayout(context);
+        LinearLayout.LayoutParams layoutParams = new LinearLayout.LayoutParams(LayoutParams.MATCH_PARENT,
+                LayoutParams.WRAP_CONTENT);
+        layoutParams.setMargins(10, 10, 10, 10);
+        mainLayout.setLayoutParams(layoutParams);
+        mainLayout.setOrientation(LinearLayout.VERTICAL);
+
+        TextView textView = new TextView(context);
+        textView.setLayoutParams(new LinearLayout.LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.WRAP_CONTENT));
+        textView.setPadding(2, 2, 2, 2);
+        textView.setText(R.string.set_maps_folder_manually);
+        mainLayout.addView(textView);
+
+        editView = new EditText(context);
+        editView.setLayoutParams(new LinearLayout.LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.WRAP_CONTENT));
+        editView.setPadding(15, 5, 15, 5);
+        editView.setText(customFolder);
+        mainLayout.addView(editView);
+
+        TextView comboLabelView = new TextView(context);
+        comboLabelView.setLayoutParams(new LinearLayout.LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.WRAP_CONTENT));
+        comboLabelView.setPadding(2, 2, 2, 2);
+        comboLabelView.setText(R.string.choose_from_suggested_folders);
+        mainLayout.addView(comboLabelView);
+
+        guessedFolderSpinner = new Spinner(context);
+        guessedFolderSpinner.setLayoutParams(new LinearLayout.LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.WRAP_CONTENT));
+        guessedFolderSpinner.setPadding(15, 5, 15, 5);
+        mainLayout.addView(guessedFolderSpinner);
+
+        TextView textView2 = new TextView(context);
+        textView2.setLayoutParams(new LinearLayout.LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.WRAP_CONTENT));
+        textView2.setPadding(2, 2, 2, 2);
+        textView2.setText(R.string.restart_after_setting_maps_folder);
+        mainLayout.addView(textView2);
+
+        // TODO get the custom root path
+        String path = ""; //$NON-NLS-1$
+        try {
+            path = ResourcesManager.getInstance(context).getMapsDir().getParent();
+        } catch (java.lang.Exception e) {
+            GPLog.error(this, "Error reading a custom tile source.", e); //$NON-NLS-1$
+        }
+
+        if (GPLog.LOG_HEAVY)
+            GPLog.addLogEntry(this, "custom maps base path: " + path); //$NON-NLS-1$
+
+        // allow routine to continue if path is empty
+        try {
+            guessedFoldersList = FileUtilities.getPossibleMapsFoldersList(path, "maps"); //$NON-NLS-1$
+        } catch (java.lang.Exception e) {
+            GPLog.error(this, "Error reading a custom tile source.", e); //$NON-NLS-1$
+        }
+
+        guessedFoldersList.add(0, ""); //$NON-NLS-1$
+
+        ArrayAdapter<String> adapter = new ArrayAdapter<String>(context, android.R.layout.simple_spinner_item, guessedFoldersList);
+        adapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
+        guessedFolderSpinner.setAdapter(adapter);
+        if (customFolder != null) {
+            for( int i = 0; i < guessedFoldersList.size(); i++ ) {
+                if (guessedFoldersList.get(i).equals(customFolder.trim())) {
+                    guessedFolderSpinner.setSelection(i);
+                    break;
+                }
+            }
+        }
+
+        return mainLayout;
+    }
+    @Override
+    protected void onBindDialogView( View v ) {
+        super.onBindDialogView(v);
+
+        editView.setText(customFolder);
+        if (customFolder != null) {
+            for( int i = 0; i < guessedFoldersList.size(); i++ ) {
+                if (guessedFoldersList.get(i).equals(customFolder.trim())) {
+                    guessedFolderSpinner.setSelection(i);
+                    break;
+                }
+            }
+        }
+    }
+
+    @Override
+    protected void onDialogClosed( boolean positiveResult ) {
+        super.onDialogClosed(positiveResult);
+
+        if (positiveResult) {
+            customFolder = editView.getText().toString().trim();
+            if (customFolder.length() == 0) {
+                // try combo
+                customFolder = guessedFolderSpinner.getSelectedItem().toString();
+            }
+            if (callChangeListener(customFolder)) {
+                persistString(customFolder);
+            }
+        }
+    }
+
+    @Override
+    protected Object onGetDefaultValue( TypedArray a, int index ) {
+        return (a.getString(index));
+    }
+
+    @Override
+    protected void onSetInitialValue( boolean restoreValue, Object defaultValue ) {
+
+        if (restoreValue) {
+            if (defaultValue == null) {
+                customFolder = getPersistedString(""); //$NON-NLS-1$
+            } else {
+                customFolder = getPersistedString(defaultValue.toString());
+            }
+        } else {
+            customFolder = defaultValue.toString();
+        }
+    }
+}

--- a/geopaparazzilibrary/src/eu/geopaparazzi/library/util/FileUtilities.java
+++ b/geopaparazzilibrary/src/eu/geopaparazzi/library/util/FileUtilities.java
@@ -47,13 +47,13 @@ public class FileUtilities {
      */
     public static List<String> getPossibleSdcardsList() {
         List<String> list_sdcards = new ArrayList<String>();
-        File dir_mnt = new File("/mnt");
+        File dir_mnt = new File("/mnt"); //$NON-NLS-1$
         if ((dir_mnt != null) && (dir_mnt.exists()) && (dir_mnt.canRead())) {
-            // '/mnt' will list the mounted directories accessable and can be soft-link's
+            // '/mnt' will list the mounted directories accessible and can be soft-links
             File[] list_files = dir_mnt.listFiles();
             for( File this_file : list_files ) {
                 if (this_file.isDirectory()) {
-                    if (this_file.getAbsolutePath().toLowerCase().indexOf("sd") != -1) {
+                    if (this_file.getAbsolutePath().toLowerCase().indexOf("sd") != -1) { //$NON-NLS-1$
                         // 'sdcard' (now shown as '/storage/emulated/0') ; 'extSdCard'
                         list_sdcards.add(this_file.getAbsolutePath().trim());
                     }
@@ -64,12 +64,35 @@ public class FileUtilities {
     }
 
     /**
-     * Copy a file.
+     * Get a list of folder names (for custom maps folder choices).
+     * Assume user prefaces the custom folder with "maps_" or 
+     * other initial letters as specified and passed to this function 
      * 
-     * @param fromFile source file.
-     * @param toFile dest file.
-     * @throws IOException  if something goes wrong. 
+     * @param path the path from which to list folders
+     * @param start the initial start letters. Can be empty string. 
+     * @return the list of possible maps folders.
      */
+    public static List<String> getPossibleMapsFoldersList( String path, String start ) {
+        List<String> list_mapsFolds = new ArrayList<String>();
+        File f = new File(path);
+        File[] file = f.listFiles();
+
+        for( File fi : file ) {
+            String name = fi.getName();
+            if (fi.isDirectory() && name.contains(start)) {
+                list_mapsFolds.add(name);
+            }
+        }
+        return list_mapsFolds;
+    }
+
+    /**
+    * Copy a file.
+    * 
+    * @param fromFile source file.
+    * @param toFile dest file.
+    * @throws IOException  if something goes wrong. 
+    */
     public static void copyFile( String fromFile, String toFile ) throws IOException {
         File in = new File(fromFile);
         File out = new File(toFile);
@@ -235,7 +258,6 @@ public class FileUtilities {
             }
         }
     }
-
 
     /**
      * Returns true if all deletions were successful. If a deletion fails, the method stops

--- a/geopaparazzilibrary/src/eu/geopaparazzi/library/util/LibraryConstants.java
+++ b/geopaparazzilibrary/src/eu/geopaparazzi/library/util/LibraryConstants.java
@@ -176,6 +176,11 @@ public interface LibraryConstants {
     public static final String PREFS_KEY_BASEFOLDER = "PREFS_KEY_BASEFOLDER"; //$NON-NLS-1$
 
     /**
+     * Key used to store and retrieve a custom maps folder name.
+     */
+    public static final String PREFS_KEY_CUSTOM_MAPSFOLDER = "PREFS_KEY_CUSTOM_MAPSFOLDER"; //$NON-NLS-1$
+
+    /**
      * Key used to store and retrieve the gps logging interval to use.
      */
     public static final String PREFS_KEY_GPSLOGGINGINTERVAL = "PREFS_KEY_GPS_LOGGING_INTERVAL"; //$NON-NLS-1$

--- a/geopaparazzilibrary/src/eu/geopaparazzi/library/util/ResourcesManager.java
+++ b/geopaparazzilibrary/src/eu/geopaparazzi/library/util/ResourcesManager.java
@@ -19,6 +19,7 @@ package eu.geopaparazzi.library.util;
 
 import static eu.geopaparazzi.library.util.LibraryConstants.PREFS_KEY_BASEFOLDER;
 import static eu.geopaparazzi.library.util.LibraryConstants.PREFS_KEY_CUSTOM_EXTERNALSTORAGE;
+import static eu.geopaparazzi.library.util.LibraryConstants.PREFS_KEY_CUSTOM_MAPSFOLDER;
 import static eu.geopaparazzi.library.util.Utilities.messageDialog;
 
 import java.io.File;
@@ -44,8 +45,8 @@ import eu.geopaparazzi.library.database.GPLog;
  */
 public class ResourcesManager implements Serializable {
     private static final long serialVersionUID = 1L;
-
-    private static final String PATH_MAPS = "maps"; //$NON-NLS-1$
+    // move down to access prefs
+    //private static final String PATH_MAPS = "maps"; //$NON-NLS-1$
 
     private static final String PATH_MEDIA = "media"; //$NON-NLS-1$
 
@@ -146,6 +147,8 @@ public class ResourcesManager implements Serializable {
          */
         SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(appContext);
         String baseFolder = preferences.getString(PREFS_KEY_BASEFOLDER, ""); //$NON-NLS-1$
+        String PATH_MAPS = preferences.getString(PREFS_KEY_CUSTOM_MAPSFOLDER, "maps"); //$NON-NLS-1$
+
         applicationDir = new File(baseFolder);
         File parentFile = applicationDir.getParentFile();
         boolean parentExists = false;


### PR DESCRIPTION
In my workflow, it would be very nice to set up many different maps folders and then direct Geopaparazzi to each, depending on need.   @moovida, I've copied all your "custom sdcard path" code and reworked it for setting custom maps folders. I've tested on two units and it seems to work.  The only glitch I wish I knew how to fix is that you need to restart geopap after changing the settings.  

If you think this might be useful, I would be thrilled if you considered adding it. If this is a bad time, this can wait and I can rebase again after you bring in the large branches you both are working on! And, if you'd rather not have this capability, that's ok too!  We will use it in our fork.

[[Note that the custom SDcard path functionality seems quirky and I could not get geopap to run on a real external SD card - there seemed to be a database access issue. I did not look into that any further. I THINK this is completely independent of this pull request.]]
