### PR TITLE
Allow loading empty layers

### DIFF
--- a/geopaparazzispatialitelibrary/src/eu/geopaparazzi/spatialite/database/spatial/core/daos/GeneralQueriesPreparer.java
+++ b/geopaparazzispatialitelibrary/src/eu/geopaparazzi/spatialite/database/spatial/core/daos/GeneralQueriesPreparer.java
@@ -492,7 +492,6 @@ public enum GeneralQueriesPreparer implements ISpatialiteTableAndFieldsNames {
             // is an invalid record and must be ignored
             sb_query.append(" WHERE (" + METADATA_VECTOR_LAYERS_TABLE_NAME + ".spatial_index_enabled = 1)");
             sb_query.append(" AND (" + METADATA_VECTOR_LAYERS_STATISTICS_TABLE_NAME + ".row_count IS NOT NULL)");
-            sb_query.append(" AND (" + METADATA_VECTOR_LAYERS_STATISTICS_TABLE_NAME + ".row_count > 0)");
             sb_query.append(" AND (" + METADATA_VECTOR_LAYERS_STATISTICS_TABLE_NAME + ".extent_min_x IS NOT NULL)");
             sb_query.append(" AND (" + METADATA_VECTOR_LAYERS_STATISTICS_TABLE_NAME + ".extent_min_y IS NOT NULL)");
             sb_query.append(" AND (" + METADATA_VECTOR_LAYERS_STATISTICS_TABLE_NAME + ".extent_max_x IS NOT NULL)");
@@ -555,11 +554,11 @@ public enum GeneralQueriesPreparer implements ISpatialiteTableAndFieldsNames {
             // is an invalid record and must be ignored
             sb_query.append(" WHERE (" + METADATA_VECTOR_LAYERS_TABLE_NAME + ".spatial_index_enabled = 0)");
             sb_query.append(" OR (" + METADATA_VECTOR_LAYERS_STATISTICS_TABLE_NAME + ".row_count IS NULL)");
-            sb_query.append(" OR (" + METADATA_VECTOR_LAYERS_STATISTICS_TABLE_NAME + ".row_count == 0)");
-            sb_query.append(" OR (" + METADATA_VECTOR_LAYERS_STATISTICS_TABLE_NAME + ".extent_min_x IS NULL)");
+            sb_query.append(" OR ((" + METADATA_VECTOR_LAYERS_STATISTICS_TABLE_NAME + ".row_count > 0)");
+            sb_query.append(" AND ((" + METADATA_VECTOR_LAYERS_STATISTICS_TABLE_NAME + ".extent_min_x IS NULL)");
             sb_query.append(" OR (" + METADATA_VECTOR_LAYERS_STATISTICS_TABLE_NAME + ".extent_min_y IS NULL)");
             sb_query.append(" OR (" + METADATA_VECTOR_LAYERS_STATISTICS_TABLE_NAME + ".extent_max_x IS NULL)");
-            sb_query.append(" OR (" + METADATA_VECTOR_LAYERS_STATISTICS_TABLE_NAME + ".extent_max_y IS NULL)");
+            sb_query.append(" OR (" + METADATA_VECTOR_LAYERS_STATISTICS_TABLE_NAME + ".extent_max_y IS NULL)))");
             VECTOR_LAYERS_QUERY_WHERE = sb_query.toString();
         }
         {


### PR DESCRIPTION
Loading empty layers (with a defined set of attributes) is very useful to capture field data