### PR TITLE
Allow loading empty layers for v4 databases

### DIFF
--- a/geopaparazzispatialitelibrary/src/eu/geopaparazzi/spatialite/database/spatial/core/daos/GeneralQueriesPreparer.java
+++ b/geopaparazzispatialitelibrary/src/eu/geopaparazzi/spatialite/database/spatial/core/daos/GeneralQueriesPreparer.java
@@ -492,11 +492,11 @@ public enum GeneralQueriesPreparer implements ISpatialiteTableAndFieldsNames {
             // is an invalid record and must be ignored
             sb_query.append(" WHERE (" + METADATA_VECTOR_LAYERS_TABLE_NAME + ".spatial_index_enabled = 1)");
             sb_query.append(" AND (" + METADATA_VECTOR_LAYERS_STATISTICS_TABLE_NAME + ".row_count IS NOT NULL)");
-            sb_query.append(" AND (" + METADATA_VECTOR_LAYERS_STATISTICS_TABLE_NAME + ".row_count > 0)");
-            sb_query.append(" AND (" + METADATA_VECTOR_LAYERS_STATISTICS_TABLE_NAME + ".extent_min_x IS NOT NULL)");
+            sb_query.append(" AND ((" + METADATA_VECTOR_LAYERS_STATISTICS_TABLE_NAME + ".row_count = 0)");
+            sb_query.append(" OR ((" + METADATA_VECTOR_LAYERS_STATISTICS_TABLE_NAME + ".extent_min_x IS NOT NULL)");
             sb_query.append(" AND (" + METADATA_VECTOR_LAYERS_STATISTICS_TABLE_NAME + ".extent_min_y IS NOT NULL)");
             sb_query.append(" AND (" + METADATA_VECTOR_LAYERS_STATISTICS_TABLE_NAME + ".extent_max_x IS NOT NULL)");
-            sb_query.append(" AND (" + METADATA_VECTOR_LAYERS_STATISTICS_TABLE_NAME + ".extent_max_y IS NOT NULL)");
+            sb_query.append(" AND (" + METADATA_VECTOR_LAYERS_STATISTICS_TABLE_NAME + ".extent_max_y IS NOT NULL)))");
             VECTOR_LAYERS_QUERY_WHERE = sb_query.toString();
         }
         String LAYERS_QUERY_WHERE = "";
@@ -555,11 +555,11 @@ public enum GeneralQueriesPreparer implements ISpatialiteTableAndFieldsNames {
             // is an invalid record and must be ignored
             sb_query.append(" WHERE (" + METADATA_VECTOR_LAYERS_TABLE_NAME + ".spatial_index_enabled = 0)");
             sb_query.append(" OR (" + METADATA_VECTOR_LAYERS_STATISTICS_TABLE_NAME + ".row_count IS NULL)");
-            sb_query.append(" OR (" + METADATA_VECTOR_LAYERS_STATISTICS_TABLE_NAME + ".row_count == 0)");
-            sb_query.append(" OR (" + METADATA_VECTOR_LAYERS_STATISTICS_TABLE_NAME + ".extent_min_x IS NULL)");
+            sb_query.append(" OR ((" + METADATA_VECTOR_LAYERS_STATISTICS_TABLE_NAME + ".row_count > 0)");
+            sb_query.append(" AND ((" + METADATA_VECTOR_LAYERS_STATISTICS_TABLE_NAME + ".extent_min_x IS NULL)");
             sb_query.append(" OR (" + METADATA_VECTOR_LAYERS_STATISTICS_TABLE_NAME + ".extent_min_y IS NULL)");
             sb_query.append(" OR (" + METADATA_VECTOR_LAYERS_STATISTICS_TABLE_NAME + ".extent_max_x IS NULL)");
-            sb_query.append(" OR (" + METADATA_VECTOR_LAYERS_STATISTICS_TABLE_NAME + ".extent_max_y IS NULL)");
+            sb_query.append(" OR (" + METADATA_VECTOR_LAYERS_STATISTICS_TABLE_NAME + ".extent_max_y IS NULL)))");
             VECTOR_LAYERS_QUERY_WHERE = sb_query.toString();
         }
         {

--- a/geopaparazzispatialitelibrary/src/eu/geopaparazzi/spatialite/database/spatial/core/daos/SPL_Vectors.java
+++ b/geopaparazzispatialitelibrary/src/eu/geopaparazzi/spatialite/database/spatial/core/daos/SPL_Vectors.java
@@ -18,6 +18,8 @@
 
 package eu.geopaparazzi.spatialite.database.spatial.core.daos;
 
+import java.text.SimpleDateFormat;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -535,11 +537,10 @@ public class SPL_Vectors implements ISpatialiteTableAndFieldsNames {
                 vector_extent = statement.column_string(2);
                 if (vector_extent != null) {
                     spatialVectorMap.put(vector_key, vector_data + vector_extent);
-                } else { // should never happen
-                    // GPLog.addLogEntry("getSpatialVectorMap_V4 vector_key["
-                    // + vector_key + "] vector_data["+ vector_data+"] vector_extent["+
-                    // vector_extent + "] VECTOR_LAYERS_QUERY["+
-                    // VECTOR_LAYERS_QUERY_EXTENT_VALID_V4 + "]");
+                } else {
+                    // should only happen when row_count is 0
+                    String time = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'").format(new Date());
+                    spatialVectorMap.put(vector_key, vector_data + "0;0.0,0.0,1.0,1.0;" + time);
                 }
             }
         } catch (jsqlite.Exception e_stmt) {


### PR DESCRIPTION
Loading empty layers (with a defined set of attributes) is very useful to capture field data