### PR TITLE
Improve DATE type handling for Spatialite databases

### DIFF
--- a/geopaparazzi.app/src/main/java/eu/hydrologis/geopaparazzi/maptools/FeaturePagerActivity.java
+++ b/geopaparazzi.app/src/main/java/eu/hydrologis/geopaparazzi/maptools/FeaturePagerActivity.java
@@ -83,7 +83,7 @@ public class FeaturePagerActivity extends AppCompatActivity implements OnPageCha
         isReadOnly = extras.getBoolean(FeatureUtilities.KEY_READONLY);
 
         selectedFeature = featuresList.get(0);
-        PagerAdapter featureAdapter = new FeaturePageAdapter(this, featuresList, isReadOnly);
+        PagerAdapter featureAdapter = new FeaturePageAdapter(this, featuresList, isReadOnly, getSupportFragmentManager());
 
         ViewPager featuresPager = (ViewPager) findViewById(R.id.featurePager);
         // ViewPager viewPager = new ViewPager(this);

--- a/geopaparazzispatialitelibrary/src/eu/geopaparazzi/spatialite/database/spatial/core/daos/DaoSpatialite.java
+++ b/geopaparazzispatialitelibrary/src/eu/geopaparazzi/spatialite/database/spatial/core/daos/DaoSpatialite.java
@@ -329,7 +329,7 @@ public class DaoSpatialite implements ISpatialiteTableAndFieldsNames {
             boolean ignore = SpatialiteUtilities.doIgnoreField(fieldName);
             if (!ignore) {
                 EDataType dataType = EDataType.getType4Name(type);
-                if (dataType == EDataType.TEXT) {
+                if (dataType == EDataType.TEXT || dataType == EDataType.DATE) {
                     value = escapeString(value);
                     sb.append(" , ").append(fieldName).append("='").append(value).append("'");
                 } else {


### PR DESCRIPTION
Currently DATE type is stored as a number in DaoSpatialite, so when you type "2016-10-05" in the feature form you finally get the number 2001 in the database (as the sql engine is substracting the 10 and 05 to the 2016), which is for sure not what the user expects.

This pull request modifies DaoSpatialite, storing dates as strings following the yyyy/mm/dd format (this is consistent with the way OGR reads/writes Spatialite DATES).

In addition, a data picker is used now to set the date in the form, to ensure we store a properly formatted string on the database.