### PR TITLE
Handle FLOAT type in SpatialVectorLayer

### DIFF
--- a/geopaparazzispatialitelibrary/src/eu/geopaparazzi/spatialite/database/spatial/core/tables/SpatialVectorTable.java
+++ b/geopaparazzispatialitelibrary/src/eu/geopaparazzi/spatialite/database/spatial/core/tables/SpatialVectorTable.java
@@ -214,6 +214,8 @@ public class SpatialVectorTable extends AbstractSpatialTable implements Serializ
                 return EDataType.DATE;
             } else if (type.contains("BLOB")) {
                 return EDataType.BLOB;
+            } else if (type.contains("FLOAT")) {
+                return EDataType.FLOAT;
             }
         }
         return null;


### PR DESCRIPTION
Currently is not possible to edit FLOAT fields in the FeaturePagerActivity, because SpatialVectorLayer does not handle them. This pull request solves the issue