### PR TITLE
Fix Feature attribute display crash

### DIFF
--- a/geopaparazzi_core/src/main/java/eu/geopaparazzi/core/maptools/FeatureUtilities.java
+++ b/geopaparazzi_core/src/main/java/eu/geopaparazzi/core/maptools/FeatureUtilities.java
@@ -122,7 +122,11 @@ public class FeatureUtilities {
                     String cName = stmt.column_name(i);
                     String value = stmt.column_string(i);
                     EDataType type = spatialTable.getTableFieldType(cName);
-                    feature.addAttribute(cName, value, type.name());
+                    if (type == null) {
+                        GPLog.addLogEntry("Featureutilities#buildWithoutGeometry", "Unexpected type for column "
+                                + cName);
+                        continue;
+                    }
                 }
                 featuresList.add(feature);
             }

--- a/geopaparazzi_core/src/main/java/eu/geopaparazzi/core/maptools/FeatureUtilities.java
+++ b/geopaparazzi_core/src/main/java/eu/geopaparazzi/core/maptools/FeatureUtilities.java
@@ -127,6 +127,7 @@ public class FeatureUtilities {
                                 + cName);
                         continue;
                     }
+					feature.addAttribute(cName, value, type.name());
                 }
                 featuresList.add(feature);
             }


### PR DESCRIPTION
Geopaparazzi will crash displaying Spatialite database features when the table has an unsupported column type lie "BIGINT".

Issue #443