### PR TITLE
View external sd

### DIFF
--- a/geopaparazzilibrary/src/main/java/eu/geopaparazzi/library/core/activities/DirectoryBrowserActivity.java
+++ b/geopaparazzilibrary/src/main/java/eu/geopaparazzi/library/core/activities/DirectoryBrowserActivity.java
@@ -236,35 +236,16 @@ public class DirectoryBrowserActivity extends ListActivity {
         if (currentDir == null)
             currentDir = sdcardDir;
         atBaseDirs = FALSE;
-        File[] extDirs = this.getExternalFilesDirs(null);
-        File[] extRootDirs = new File[extDirs.length];
         File tmpDir = currentDir.getParentFile();
         if (tmpDir != null && tmpDir.exists()) {
-            //GPLog.addLogEntry("dirBrowse currentDir: ", currentDir.getAbsolutePath());
             if (tmpDir.canRead()) {
                 currentDir = tmpDir;
             } else {
-                for (int i = 0; i < extDirs.length; i++) {
-                    //GPLog.addLogEntry("dirBrowse extDirs ", i + ": " + extDirs[i]);
-                    String regex = "/Android/data/eu.hydrologis.geopaparazzi/files";
-                    extRootDirs[i] = new File(extDirs[i].toString().replaceAll(regex, ""));
-                    //GPLog.addLogEntry("dirBrowse extRootDirs ", i + ": " + extRootDirs[i]);
-                }
-                currentDir = extRootDirs[0];
                 atBaseDirs = TRUE;
             }
         }
         if (atBaseDirs) {
-            filesList.clear();
-            for (File file : extRootDirs) {
-                if (!doHidden && file.getName().startsWith(".")) { //$NON-NLS-1$
-                    continue;
-                }
-                filesList.add(file);
-                Collections.sort(filesList, new FileNameComparator());
-            }
-            fileListAdapter = new FileArrayAdapter(this, filesList);
-            setListAdapter(fileListAdapter);
+            getBaseFiles();
         } else {
             getFiles(currentDir, currentDir.listFiles(fileFilter));
         }
@@ -290,6 +271,27 @@ public class DirectoryBrowserActivity extends ListActivity {
         } else {
             fileListAdapter.notifyDataSetChanged();
         }
+    }
+
+    private void getBaseFiles(){
+        File[] extDirs = this.getExternalFilesDirs(null);
+        File[] extRootDirs = new File[extDirs.length];
+        // remove the portion of the path that getExternalFilesDirs returns
+        // that we don't want
+        for (int i = 0; i < extDirs.length; i++) {
+            String regex = "/Android/data/eu.hydrologis.geopaparazzi/files";
+            extRootDirs[i] = new File(extDirs[i].toString().replaceAll(regex, ""));
+        }
+        filesList.clear();
+        for (File file : extRootDirs) {
+            if (!doHidden && file.getName().startsWith(".")) { //$NON-NLS-1$
+                continue;
+            }
+            filesList.add(file);
+            Collections.sort(filesList, new FileNameComparator());
+        }
+        fileListAdapter = new FileArrayAdapter(this, filesList);
+        setListAdapter(fileListAdapter);
     }
 
     private class FileArrayAdapter extends ArrayAdapter<File> {

--- a/geopaparazzilibrary/src/main/res/values/strings.xml
+++ b/geopaparazzilibrary/src/main/res/values/strings.xml
@@ -107,6 +107,8 @@
     <string name="set_properties">Set properties</string>
     <string name="set_dash">Set Dash</string>
     <string name="unauthorized_api_key">Unauthorized access. Check your API-key.</string>
+    <string name="sd_card_foldername">External SD Card</string>
+    <string name="internal_card_foldername">Internal Storage</string>
 
     <string name="fill_and_stroke_color_title">Fill and Stroke color</string>
     <string name="fill_color_title">Fill color</string>


### PR DESCRIPTION
Second try!  A bit cleaner.   Copying my comments from my first try:

I've tried to address this issues noted here: #440
and possibly here: #412

I've tested this on a Nexus 5 running Android 6.0.1 with no external SD card as well as other phones and tablets with external SD cards and it seems pretty good so far.

I've implemented it here: https://github.com/geopaparazzi/geopaparazzi/blob/master/geopaparazzilibrary/src/main/java/eu/geopaparazzi/library/core/activities/DirectoryBrowserActivity.java

but you may want to implement it up at https://github.com/geopaparazzi/geopaparazzi/blob/master/geopaparazzilibrary/src/main/java/eu/geopaparazzi/library/core/ResourcesManager.java

If so, I hope some of the ideas here can help.

Most exciting is that you can add basemaps from internal and external sources and they all load! Most concerning is that you can browse to spatialite sources and see them but they will not load (selected_file_no_vector_data error).