### PR TITLE
File view

### DIFF
--- a/geopaparazzi_core/src/main/java/eu/geopaparazzi/core/maptools/resourceviews/ResourceBrowser.java
+++ b/geopaparazzi_core/src/main/java/eu/geopaparazzi/core/maptools/resourceviews/ResourceBrowser.java
@@ -134,13 +134,21 @@ public class ResourceBrowser extends AppCompatActivity {
                 // the item resource only contains the thumbnail,
                 // so we need to get the complete resource
                 BlobResource completeRes = storage.getBlobResource(res.getId());
-                AppsUtilities.showImage(completeRes.getBlob(), blobRes.getName(), this);
+                if (res.getType() == AbstractResource.ResourceType.BLOB_IMAGE) {
+                    AppsUtilities.showImage(completeRes.getBlob(), blobRes.getName(), this);
+                } else if (res.getType() == AbstractResource.ResourceType.BLOB_PDF) {
+                    AppsUtilities.showPDF(completeRes.getBlob(), blobRes.getName(), this);
+                }
+
             }
             else {
                 ExternalResource extRes = (ExternalResource) res;
                 File image = new File(imageSaveFolder, extRes.getPath());
-                AppsUtilities.showImage(image, this);
-
+                if (res.getType() == AbstractResource.ResourceType.BLOB_IMAGE) {
+                    AppsUtilities.showImage(image, this);
+                } else if (res.getType() == AbstractResource.ResourceType.BLOB_PDF) {
+                    AppsUtilities.showPDF(image, this);
+                }
             }
         } catch (Exception e) {
             GPLog.error(this, null, e);
@@ -187,7 +195,7 @@ public class ResourceBrowser extends AppCompatActivity {
 
     private ArrayList<ImageItem> refreshBlobThumbnails(ArrayList<ImageItem> imageItems) {
         imageItems.clear();
-        List<BlobResource> resources = storage.getBlobThumbnails(rowId, AbstractResource.ResourceType.BLOB_IMAGE);
+        List<BlobResource> resources = storage.getBlobThumbnails(rowId); //, AbstractResource.ResourceType.BLOB_IMAGE);
         int i=0;
         for (BlobResource r: resources) {
             Bitmap bitmap = BitmapFactory.decodeByteArray(r.getThumbnail(), 0, r.getThumbnail().length);

--- a/geopaparazzi_core/src/main/java/eu/geopaparazzi/core/maptools/resourceviews/ResourceBrowser.java
+++ b/geopaparazzi_core/src/main/java/eu/geopaparazzi/core/maptools/resourceviews/ResourceBrowser.java
@@ -172,7 +172,7 @@ public class ResourceBrowser extends AppCompatActivity {
     private ArrayList<ImageItem> refreshExternalImages(ArrayList<ImageItem> imageItems) {
         imageItems.clear();
         List<ExternalResource> resources = storage.getExternalResources(rowId, AbstractResource.ResourceType.EXTERNAL_IMAGE);
-        int i=0;
+        int i=1;
         for (ExternalResource r: resources) {
             String imgPath = r.getPath();
             File imgFile = new File(imgPath);
@@ -185,7 +185,8 @@ public class ResourceBrowser extends AppCompatActivity {
             }
 
             Bitmap bitmap = ImageUtilities.decodeSampledBitmapFromFile(absPath, 100, 100);
-            imageItems.add(new ImageItem(bitmap, "Image#" + i++, r));
+            String title = getResources().getString(R.string.Image_title);
+            imageItems.add(new ImageItem(bitmap, title + i++, r));
         }
         String text = getResources().getQuantityString(R.plurals.n_images, imageItems.size(), imageItems.size());
         numImagesView.setText(text);
@@ -196,10 +197,11 @@ public class ResourceBrowser extends AppCompatActivity {
     private ArrayList<ImageItem> refreshBlobThumbnails(ArrayList<ImageItem> imageItems) {
         imageItems.clear();
         List<BlobResource> resources = storage.getBlobThumbnails(rowId); //, AbstractResource.ResourceType.BLOB_IMAGE);
-        int i=0;
+        int i=1;
         for (BlobResource r: resources) {
             Bitmap bitmap = BitmapFactory.decodeByteArray(r.getThumbnail(), 0, r.getThumbnail().length);
-            imageItems.add(new ImageItem(bitmap, "Image#" + i++, r));
+            String title = getResources().getString(R.string.Image_title);
+            imageItems.add(new ImageItem(bitmap, title + i++, r));
         }
         String text = getResources().getQuantityString(R.plurals.n_images, imageItems.size(), imageItems.size());
         numImagesView.setText(text);

--- a/geopaparazzi_core/src/main/java/eu/geopaparazzi/core/maptools/tools/InfoTool.java
+++ b/geopaparazzi_core/src/main/java/eu/geopaparazzi/core/maptools/tools/InfoTool.java
@@ -251,7 +251,7 @@ public class InfoTool extends MapTool {
                             Intent intent = new Intent(context, FeaturePagerActivity.class);
                             intent.putParcelableArrayListExtra(FeatureUtilities.KEY_FEATURESLIST,
                                     (ArrayList<? extends Parcelable>) features);
-                            intent.putExtra(FeatureUtilities.KEY_READONLY, true);
+                            intent.putExtra(FeatureUtilities.KEY_READONLY, false ); //true);
                             context.startActivity(intent);
                         }
                     }

--- a/geopaparazzi_core/src/main/res/values/strings.xml
+++ b/geopaparazzi_core/src/main/res/values/strings.xml
@@ -161,7 +161,7 @@
     <string name="select_map_to_use">Select map to use</string>
     <string name="no_map_file_found_going_to_mapnik">Could not find map file, switching to MAPNIK tile source.</string>
     <string name="enter_project_description">Enter a description for the project</string>
-    <string name="no_images">No Images</string>
+    <string name="no_images">No Documents</string>
     <string name="with_images">With Images</string>
     <string name="successfully_imported_bookmarks">"Successfully imported bookmarks: "</string>
     <string name="error_bookmarks_import">An error occurred while importing the bookmarks.</string>
@@ -395,15 +395,16 @@
     <string name="import_cloud_data">Cloud Data</string>
     <string name="browse_images">Browse images</string>
     <string name="new_picture">New picture</string>
-    <string name="Images">Images</string>
-    <string name="confirm_remove_image">Do you really want to remove the image?</string>
+    <string name="Images">Documents</string>
+    <string name="Image_title">Document#</string>
+    <string name="confirm_remove_image">Do you really want to remove the document?</string>
     <string name="upload_to_cloud_prompt">Upload the current project to the cloud?</string>
     <string name="data_to_pdf_label">Project Forms to Pdf</string>
     <string name="exporting_data_to_pdf">Exporting form data to PDF</string>
 
     <plurals name="n_images">
-        <item quantity="one">1 image</item>
-        <item quantity="other">%d images</item>
+        <item quantity="one">1 document</item>
+        <item quantity="other">%d documents</item>
     </plurals>
 
     <!-- geoss2go profiles -->

--- a/geopaparazzilibrary/src/main/java/eu/geopaparazzi/library/util/AppsUtilities.java
+++ b/geopaparazzilibrary/src/main/java/eu/geopaparazzi/library/util/AppsUtilities.java
@@ -287,6 +287,33 @@ public class AppsUtilities {
         context.startActivity(intent);
     }
 
+    public static void showPDF(byte[] pdfData, String pdfName, Context context) throws Exception {
+        File tempDir = ResourcesManager.getInstance(context).getTempDir();
+        String ext = ".pdf";
+
+        File pdfFile = new File(tempDir, ImageUtilities.getTempImageName(ext));
+        ImageUtilities.writeImageDataToFile(pdfData, pdfFile.getAbsolutePath());
+
+        showPDF(pdfFile, context);
+    }
+
+    /**
+     * Show PDF.
+     *
+     * @param pdfFile the image file.
+     * @param context   the context to use.
+     * @throws Exception
+     */
+    public static void showPDF(File pdfFile, Context context) throws Exception {
+        Intent intent = new Intent();
+        intent.setAction(Intent.ACTION_VIEW);
+        Uri uri = Utilities.getFileUriInApplicationFolder(context, pdfFile);
+        intent.setDataAndType(uri, "application/pdf"); //$NON-NLS-1$
+
+        grantPermission(context, intent, uri);
+        context.startActivity(intent);
+    }
+
 
     /**
      * Grant permission to access a file from another app.

--- a/geopaparazzispatialitelibrary/src/eu/geopaparazzi/spatialite/database/spatial/core/resourcestorage/AbstractResource.java
+++ b/geopaparazzispatialitelibrary/src/eu/geopaparazzi/spatialite/database/spatial/core/resourcestorage/AbstractResource.java
@@ -7,6 +7,7 @@ public abstract class AbstractResource {
     private long id;
     private String name;
     private ResourceType type;
+    private Boolean isExternal;
 
     public enum ResourceType {
         EXTERNAL_IMAGE,
@@ -23,7 +24,14 @@ public abstract class AbstractResource {
         this.id = id;
         this.name = name;
         this.type = type;
+        if (this.type.ordinal() < ResourceType.BLOB_IMAGE.ordinal() ) {
+            this.isExternal = true;
+        } else {
+            this.isExternal = false;
+        }
     }
+
+    public Boolean isExternal() { return this.isExternal; }
 
     /**
      * Gets the name of the resource (title or textual description)
@@ -60,6 +68,11 @@ public abstract class AbstractResource {
      */
     public void setType(ResourceType type) {
         this.type = type;
+        if (this.type.ordinal() < ResourceType.BLOB_IMAGE.ordinal() ) {
+            this.isExternal = true;
+        } else {
+            this.isExternal = false;
+        }
     }
 
     /**

--- a/geopaparazzispatialitelibrary/src/eu/geopaparazzi/spatialite/database/spatial/core/resourcestorage/ResourceStorage.java
+++ b/geopaparazzispatialitelibrary/src/eu/geopaparazzi/spatialite/database/spatial/core/resourcestorage/ResourceStorage.java
@@ -90,7 +90,6 @@ public class ResourceStorage {
 
         return result;
     }
-
     public ExternalResource getExternalResource(long id) {
         StringBuffer buffer = new StringBuffer();
         buffer.append("SELECT ");
@@ -131,12 +130,12 @@ public class ResourceStorage {
         StringBuffer buffer = new StringBuffer();
         buffer.append("SELECT ");
         buffer.append(ID_FIELD).append(", ").append(RESBLOB_FIELD).append(", ").append(RESNAME_FIELD);
-        buffer.append(", ").append(RESBLOBTHUMB_FIELD);
+        buffer.append(", ").append(RESBLOBTHUMB_FIELD).append(", ").append(RESTYPE_FIELD);
         buffer.append(" FROM ").append(AUX_TABLE_NAME);
         buffer.append(" WHERE ");
         buffer.append(RESTABLE_FIELD).append("='").append(this.tableName).append("' AND ");
-        buffer.append(ROWFK_FIELD).append("=").append(rowIdFk).append(" AND ");
-        buffer.append(RESTYPE_FIELD).append("='").append(type.toString()).append("'");
+        buffer.append(ROWFK_FIELD).append("=").append(rowIdFk); //.append(" AND ");
+//        buffer.append(RESTYPE_FIELD).append("='").append(type.toString()).append("'");
 
         String sqlCommand = buffer.toString();
         Stmt statement = null;
@@ -167,16 +166,15 @@ public class ResourceStorage {
 
         return result;
     }
-
-    public List<BlobResource> getBlobThumbnails(long rowIdFk, BlobResource.ResourceType type) {
+    public List<BlobResource> getBlobThumbnails(long rowIdFk) { //}, BlobResource.ResourceType type) {
         StringBuffer buffer = new StringBuffer();
         buffer.append("SELECT ");
-        buffer.append(ID_FIELD).append(", ").append(RESBLOBTHUMB_FIELD).append(", ").append(RESNAME_FIELD);
+        buffer.append(ID_FIELD).append(", ").append(RESBLOBTHUMB_FIELD).append(", ").append(RESNAME_FIELD).append(", ").append(RESTYPE_FIELD);
         buffer.append(" FROM ").append(AUX_TABLE_NAME);
         buffer.append(" WHERE ");
         buffer.append(RESTABLE_FIELD).append("='").append(this.tableName).append("' AND ");
-        buffer.append(ROWFK_FIELD).append("=").append(rowIdFk).append(" AND ");
-        buffer.append(RESTYPE_FIELD).append("='").append(type.toString()).append("'");
+        buffer.append(ROWFK_FIELD).append("=").append(rowIdFk); //.append(" AND ");
+//        buffer.append(RESTYPE_FIELD).append("='").append(type.toString()).append("'");
 
         String sqlCommand = buffer.toString();
         Stmt statement = null;
@@ -187,6 +185,8 @@ public class ResourceStorage {
                 long id = statement.column_long(0);
                 byte[] thumbnail = statement.column_bytes(1);
                 String name = statement.column_string(2);
+                String typeStr = statement.column_string(3);
+                AbstractResource.ResourceType type = AbstractResource.ResourceType.valueOf(typeStr);
                 BlobResource res = new BlobResource(id, null, name, type);
                 res.setThumbnail(thumbnail);
                 result.add(res);


### PR DESCRIPTION
This pull request slightly expands the Feature linking system to allow viewing of PDF files as blobs in a  Spatialite database.

It relaxes the the database query to get BLOB_PDF (as well as BLOB_IMAGE).
It changes the Feature display on a select-for-view to be read-only=false so the linked-files button shows up.

These changes are simply to get people using Feature linking and see if there is enough interest to do more.

Under the current set of objects, adding code to allow EXTERNAL file links and other file types will require the replication a lot of code and generally make the code more complex.  The better solution would be to refactor the objects to simply have a Resource object with a few more properties to eventual issue an intent to Android to display the file.