### PR TITLE
handle case when getExternalFilesDir returns a null

### DIFF
--- a/geopaparazzilibrary/src/main/java/eu/geopaparazzi/library/core/ResourcesManager.java
+++ b/geopaparazzilibrary/src/main/java/eu/geopaparazzi/library/core/ResourcesManager.java
@@ -169,13 +169,19 @@ public class ResourcesManager implements Serializable {
         // remove the portion of the path that getExternalFilesDirs returns
         // that we don't want
         for (int i = 0; i < extDirs.length; i++) {
-            String regex = "/Android/data/" + getPackageName() + "/files";
-            extRootDirs[i] = new File(extDirs[i].toString().replaceAll(regex, ""));
+            if (extDirs[i] == null){
+                continue;
+            } else {
+                String regex = "/Android/data/" + getPackageName() + "/files";
+                extRootDirs[i] = new File(extDirs[i].toString().replaceAll(regex, ""));
+            }
         }
 
         for (File file : extRootDirs) {
-            if (file.exists()) {
-                if (file.canWrite()) {
+            if (file == null){
+                continue;
+            } else if (file.exists()) {
+                if (file.canWrite() & mainStorageDir == null) {
                     mainStorageDir = file;
                 } else if (file.canRead()) {
                     otherStorageDirs.add(file);


### PR DESCRIPTION
I tested the new changes that allow browsing to the SDcard and, unfortunately, it didn't go as smoothly as hoped!  On an Android 4.4.2 tablet with no SDcard installed, the getExternalFilesDirs seems to still return two items, with the second item null!  These changes deal with that problem.

*Also* the code as written would set the externalSD card as the install location (mainStorageDir) because it was always the second in the loop, here https://github.com/geopaparazzi/geopaparazzi/compare/master...tghoward:master#diff-f547c4eb67fe35ea10c80d7ee7e404e1R180 so I set it to keep the first assignment of mainStorageDir (here: https://github.com/geopaparazzi/geopaparazzi/compare/master...tghoward:master#diff-f547c4eb67fe35ea10c80d7ee7e404e1R184).

There still seems to be a problem with reading spatialite DBs with older versions of Android, but I wanted to get these fixes to you quickly because unchanged it crashing my units. 

I've also tested these fixes on newer tablets and phones. Seems ok now!