### PR TITLE
enable cancel button on Cloud Profile file download

### DIFF
--- a/geopaparazzilibrary/src/main/java/eu/geopaparazzi/library/webprofile/WebProfilesListActivity.java
+++ b/geopaparazzilibrary/src/main/java/eu/geopaparazzi/library/webprofile/WebProfilesListActivity.java
@@ -286,7 +286,7 @@ public class WebProfilesListActivity extends AppCompatActivity implements Progre
 
         downloadProfile = selectedWebprofile;
         progressBarDialogFragment = ProgressBarDialogFragment.newInstance(downloadables.toArray(new Parcelable[downloadables.size()]));
-        progressBarDialogFragment.setCancelable(false);
+        progressBarDialogFragment.setCancelable(true);
         progressBarDialogFragment.show(getSupportFragmentManager(), "Download files");
 
     }


### PR DESCRIPTION
some of the file downloads could be gigabytes, so best to give the user the option.