### PR TITLE
fix problems with photos on android 11

### DIFF
--- a/geopaparazzi_core/src/main/java/eu/geopaparazzi/core/database/DaoImages.java
+++ b/geopaparazzi_core/src/main/java/eu/geopaparazzi/core/database/DaoImages.java
@@ -479,8 +479,11 @@ public class DaoImages implements IImagesDbHelper {
             if (!c.isAfterLast()) {
                 imageData = c.getBlob(0);
             }
-        } catch (Exception ex) {
-//            if (ex.getLocalizedMessage().contains("Couldn't read row")) {
+        } catch (Exception e) {
+            GPLog.error(this, null, e);
+        }
+
+        if (imageData == null) {
             try {
                 String sizeQuery = "SELECT " + ImageDataTableFields.COLUMN_ID.getFieldName() +//
                         ", length(" + ImageDataTableFields.COLUMN_IMAGE.getFieldName() + ") " +//
@@ -521,13 +524,11 @@ public class DaoImages implements IImagesDbHelper {
                     bout.close();
                 }
             } catch (Exception e) {
-                Throwable throwable = e.initCause(ex);
-                GPLog.error(this, null, throwable);
+                GPLog.error(this, null, e);
             }
-
-        } finally {
-            c.close();
         }
+        c.close();
+
         return imageData;
     }
 

--- a/geopaparazzi_library/src/main/java/eu/geopaparazzi/library/camera/AbstractCameraActivity.java
+++ b/geopaparazzi_library/src/main/java/eu/geopaparazzi/library/camera/AbstractCameraActivity.java
@@ -195,7 +195,7 @@ public abstract class AbstractCameraActivity extends Activity {
             }
             for (File cameraTakenFile : cameraTakenMediaFiles) {
                 // delete the one duplicated
-                cameraTakenFile.delete();
+                //cameraTakenFile.delete();
             }
         } catch (Exception e) {
             GPLog.error(this, null, e);


### PR DESCRIPTION
After updating to Android 11 the two following problems with photos appeared:

1. Taking new photos is not possible anymore (new photos are always deleted in the filesystem before stored in the database).
2. A lot of previously taken photos could not be opened anymore

These two issues are solved by this PR.